### PR TITLE
Rename Test2::Bundle::Spec to Test2::Bundle::SpecDeclare

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -28,6 +28,7 @@ Carp = 1.03
 
 [Prereqs / TestRequires]
 Test2           = 0.000025
+Test2::Bundle::SpecDeclare = 0
 Test2::Suite    = 0.000020
 Test2::Workflow = 0.000005
 

--- a/t/Mask.t
+++ b/t/Mask.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Spec -target => 'Trace::Mask';
+use Test2::Bundle::SpecDeclare -target => 'Trace::Mask';
 
 ref_is($CLASS->masks, \%Trace::Mask::MASKS, "Got the reference");
 

--- a/t/Test.t
+++ b/t/Test.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Spec;
+use Test2::Bundle::SpecDeclare;
 
 use Trace::Mask::Test;
 use Trace::Mask::Reference qw/trace/;

--- a/t/TryTiny.t
+++ b/t/TryTiny.t
@@ -1,6 +1,6 @@
 use Test2::Require::Module Carp => '1.03';
 use Test2::Require::Module 'Try::Tiny' => '0.03';
-use Test2::Bundle::Spec;
+use Test2::Bundle::SpecDeclare;
 
 use Trace::Mask::TryTiny;
 use Trace::Mask::Carp qw/longmess/;

--- a/t/Util.t
+++ b/t/Util.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Spec -target => 'Trace::Mask::Util';
+use Test2::Bundle::SpecDeclare -target => 'Trace::Mask::Util';
 use Trace::Mask;
 
 use Trace::Mask::Util qw{

--- a/t/special.t
+++ b/t/special.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Spec;
+use Test2::Bundle::SpecDeclare;
 use Trace::Mask::Reference qw/trace trace_string/;
 use Trace::Mask::Util qw/update_mask/;
 use Data::Dumper;


### PR DESCRIPTION
The Test2::Bundle::Spec module was moved to Test2-Plugin-SpecDeclare
distribution under Test2::Bundle::SpecDeclare name.

https://github.com/exodist/Trace-Mask/issues/4
